### PR TITLE
Remove "--std=c89" from config-unix.mk

### DIFF
--- a/config-unix.mk
+++ b/config-unix.mk
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 E=
-CSTDFLAG=--std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter
+CSTDFLAG=-pedantic -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -g
 CPPFLAGS += -Isrc
 LINKFLAGS=-lm


### PR DESCRIPTION
I need this to build on 32-bit Centos 5.  It seems to work, but it would be nice if it could be checked that it does not break anything.  Perhaps It would be best to submit upstream, and ask if the "--std=c89" is there for a reason?  (Unless someone here knows...)
