### PR TITLE
make uv_dlopen(NULL, ...) work on Windows (like Unix)

### DIFF
--- a/src/win/dl.c
+++ b/src/win/dl.c
@@ -31,11 +31,17 @@ int uv_dlopen(const char* filename, uv_lib_t* lib) {
   lib->handle = NULL;
   lib->errmsg = NULL;
 
-  if (!uv_utf8_to_utf16(filename, filename_w, ARRAY_SIZE(filename_w))) {
-    return uv__dlerror(lib, GetLastError());
+  if (filename) {
+    if (!uv_utf8_to_utf16(filename, filename_w, ARRAY_SIZE(filename_w))) {
+      return uv__dlerror(lib, GetLastError());
+    }
+    lib->handle = LoadLibraryExW(filename_w, NULL, 
+                                 LOAD_WITH_ALTERED_SEARCH_PATH);
+  }
+  else { /* load global namespace (handle to calling executable) */
+    lib->handle = GetModuleHandle(NULL);
   }
 
-  lib->handle = LoadLibraryExW(filename_w, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
   if (lib->handle == NULL) {
     return uv__dlerror(lib, GetLastError());
   }


### PR DESCRIPTION
On Unix, `dlopen(NULL, ...)` returns a handle to the symbols of the main program.  To make the same thing work for Windows, you need to call [GetModuleHandle](http://msdn.microsoft.com/en-us/library/windows/desktop/ms683199%28v=vs.85%29.aspx) instead of [LoadLibraryEx](http://msdn.microsoft.com/en-us/library/windows/desktop/ms684179%28v=vs.85%29.aspx) in this case.  That is what the attached patch does.

(Context: in my PyCall module for Julia, we use `dlopen` to open the libpython library.  But we want to use this from IPython where the Python process is already running, and in order to use the identical PyCall code we need to `dlopen(NULL)` to look up symbols in the main program.)
