### PR TITLE
Primarily, modify the libuv API to accomodate flags to uv_tcp_init()

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1056,7 +1056,7 @@ enum uv_pipe_flags {
 	UV_PIPE_IPC			 = 0x01,
 	UV_PIPE_SPAWN_SAFE	 = 0x02,
 	UV_PIPE_READABLE	 = 0x04,
-	UV_PIPE_WRITEABLE	 = 0x08
+	UV_PIPE_WRITABLE	 = 0x08
 };
 /*
  * Initialize a pipe. The last argument is a boolean to indicate if

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -41,7 +41,7 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int flags) {
   handle->flags |= ((flags&UV_PIPE_IPC)?UV_HANDLE_PIPE_IPC:0)|
           ((flags&UV_PIPE_SPAWN_SAFE)?UV_HANDLE_PIPE_SPAWN_SAFE:0)|
           ((flags&UV_PIPE_READABLE)?UV_STREAM_READABLE:0)|
-          ((flags&UV_PIPE_WRITEABLE)?UV_STREAM_WRITABLE:0);
+          ((flags&UV_PIPE_WRITABLE)?UV_STREAM_WRITABLE:0);
   /*if (flags == 0 || flags == 1)
       handle->flags |= UV_STREAM_READABLE|UV_STREAM_WRITABLE;*/
   return 0;

--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -88,7 +88,7 @@ int uv_pipe_init(uv_loop_t* loop, uv_pipe_t* handle, int flags) {
   handle->flags |= ((flags&UV_PIPE_IPC)?UV_HANDLE_PIPE_IPC:0)|
                     ((flags&UV_PIPE_SPAWN_SAFE)?UV_HANDLE_PIPE_SPAWN_SAFE:0)|
                     ((flags&UV_PIPE_READABLE)?UV_HANDLE_READABLE:0)|
-                    ((flags&UV_PIPE_WRITEABLE)?UV_HANDLE_WRITABLE:0);
+                    ((flags&UV_PIPE_WRITABLE)?UV_HANDLE_WRITABLE:0);
 
   uv_req_init(loop, (uv_req_t*) &handle->ipc_header_write_req);
 

--- a/test/benchmark-spawn.c
+++ b/test/benchmark-spawn.c
@@ -116,7 +116,7 @@ static void spawn(void) {
   options.exit_cb = exit_cb;
 
   uv_pipe_init(loop, &out, UV_PIPE_READABLE);
-  uv_pipe_init(loop, &child_stdout, UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITEABLE);
+  uv_pipe_init(loop, &child_stdout, UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITABLE);
   r = uv_pipe_link(&out,&child_stdout);
   ASSERT( r == 0 );
 

--- a/test/test-ipc-send-recv.c
+++ b/test/test-ipc-send-recv.c
@@ -68,7 +68,7 @@ static void recv_cb(uv_pipe_t* handle,
   ASSERT(nread >= 0);
 
   if (pending == UV_NAMED_PIPE)
-    r = uv_pipe_init(ctx.channel.loop, &ctx.recv.pipe, UV_PIPE_READABLE|UV_PIPE_WRITEABLE);
+    r = uv_pipe_init(ctx.channel.loop, &ctx.recv.pipe, UV_PIPE_READABLE|UV_PIPE_WRITABLE);
   else if (pending == UV_TCP)
     r = uv_tcp_init(ctx.channel.loop, &ctx.recv.tcp);
   else
@@ -117,7 +117,7 @@ TEST_IMPL(ipc_send_recv_pipe) {
 
   ctx.expected_type = UV_NAMED_PIPE;
 
-  r = uv_pipe_init(uv_default_loop(), &ctx.send.pipe, UV_PIPE_READABLE|UV_PIPE_WRITEABLE|UV_PIPE_IPC);
+  r = uv_pipe_init(uv_default_loop(), &ctx.send.pipe, UV_PIPE_READABLE|UV_PIPE_WRITABLE|UV_PIPE_IPC);
   ASSERT(r == 0);
 
   r = uv_pipe_bind(&ctx.send.pipe, TEST_PIPENAME);
@@ -172,7 +172,7 @@ static void read2_cb(uv_pipe_t* handle,
   buf = uv_buf_init(".", 1);
 
   if (pending == UV_NAMED_PIPE)
-    r = uv_pipe_init(ctx.channel.loop, &ctx.recv.pipe, UV_PIPE_READABLE|UV_PIPE_WRITEABLE);
+    r = uv_pipe_init(ctx.channel.loop, &ctx.recv.pipe, UV_PIPE_READABLE|UV_PIPE_WRITABLE);
   else if (pending == UV_TCP)
     r = uv_tcp_init(ctx.channel.loop, &ctx.recv.tcp);
   else
@@ -199,7 +199,7 @@ int ipc_send_recv_helper(void) {
 
   memset(&ctx, 0, sizeof(ctx));
 
-  r = uv_pipe_init(uv_default_loop(), &ctx.channel, UV_PIPE_READABLE|UV_PIPE_WRITEABLE|UV_PIPE_IPC);
+  r = uv_pipe_init(uv_default_loop(), &ctx.channel, UV_PIPE_READABLE|UV_PIPE_WRITABLE|UV_PIPE_IPC);
   ASSERT(r == 0);
 
   uv_pipe_open(&ctx.channel, 0);

--- a/test/test-ipc.c
+++ b/test/test-ipc.c
@@ -204,10 +204,10 @@ void spawn_helper(uv_pipe_t* channel,
   uv_pipe_t child_channel;
 
   r = uv_pipe_init(uv_default_loop(), channel,
-	  UV_PIPE_READABLE|UV_PIPE_WRITEABLE|UV_PIPE_IPC);
+	  UV_PIPE_READABLE|UV_PIPE_WRITABLE|UV_PIPE_IPC);
   ASSERT(r == 0);
   r = uv_pipe_init(uv_default_loop(), &child_channel,
-	  UV_PIPE_READABLE|UV_PIPE_WRITEABLE);
+	  UV_PIPE_READABLE|UV_PIPE_WRITABLE);
   ASSERT(r == 0);
   r = uv_pipe_link(&child_channel,channel);
   ASSERT(r == 0);
@@ -544,7 +544,7 @@ int ipc_helper(int listen_after_write) {
   int r;
   uv_buf_t buf;
 
-  r = uv_pipe_init(uv_default_loop(), &channel, UV_PIPE_READABLE|UV_PIPE_WRITEABLE|UV_PIPE_IPC);
+  r = uv_pipe_init(uv_default_loop(), &channel, UV_PIPE_READABLE|UV_PIPE_WRITABLE|UV_PIPE_IPC);
   ASSERT(r == 0);
 
   uv_pipe_open(&channel, 0);
@@ -594,7 +594,7 @@ int ipc_helper_tcp_connection(void) {
   int r;
   struct sockaddr_in addr;
 
-  r = uv_pipe_init(uv_default_loop(), &channel, UV_PIPE_READABLE|UV_PIPE_WRITEABLE|UV_PIPE_IPC);
+  r = uv_pipe_init(uv_default_loop(), &channel, UV_PIPE_READABLE|UV_PIPE_WRITABLE|UV_PIPE_IPC);
   ASSERT(r == 0);
 
   uv_pipe_open(&channel, 0);

--- a/test/test-spawn.c
+++ b/test/test-spawn.c
@@ -185,7 +185,7 @@ TEST_IMPL(spawn_stdout) {
   init_process_options("spawn_helper2", exit_cb);
 
   uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &child_stdout, UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITEABLE);
+  uv_pipe_init(uv_default_loop(), &child_stdout, UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITABLE);
   r = uv_pipe_link(&out,&child_stdout);
   ASSERT(r == 0);
 
@@ -284,9 +284,9 @@ TEST_IMPL(spawn_stdin) {
   init_process_options("spawn_helper3", exit_cb);
 
   uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITEABLE);
+  uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITABLE);
   uv_pipe_init(uv_default_loop(), &child_pipes[0], UV_PIPE_READABLE|UV_PIPE_SPAWN_SAFE);
-  uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITEABLE|UV_PIPE_SPAWN_SAFE);
+  uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITABLE|UV_PIPE_SPAWN_SAFE);
   r = uv_pipe_link(&child_pipes[0],&in);
   ASSERT(r == 0);
   r = uv_pipe_link(&out,&child_pipes[1]);
@@ -337,7 +337,7 @@ TEST_IMPL(spawn_stdio_greater_than_3) {
   init_process_options("spawn_helper5", exit_cb);
 
   uv_pipe_init(uv_default_loop(), &pipe, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &child_pipe, UV_PIPE_WRITEABLE|UV_PIPE_SPAWN_SAFE);
+  uv_pipe_init(uv_default_loop(), &child_pipe, UV_PIPE_WRITABLE|UV_PIPE_SPAWN_SAFE);
   r = uv_pipe_link(&pipe,&child_pipe);
   ASSERT(r == 0);
   options.stdio = stdio;
@@ -424,7 +424,7 @@ TEST_IMPL(spawn_preserve_env) {
   init_process_options("spawn_helper7", exit_cb);
   
   uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &child_out, UV_PIPE_WRITEABLE|UV_PIPE_SPAWN_SAFE);
+  uv_pipe_init(uv_default_loop(), &child_out, UV_PIPE_WRITABLE|UV_PIPE_SPAWN_SAFE);
   r = uv_pipe_link(&out,&child_out);
   ASSERT(r == 0);
 
@@ -503,7 +503,7 @@ TEST_IMPL(spawn_and_kill_with_std) {
 
   init_process_options("spawn_helper4", kill_cb);
 
-  r = uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITEABLE);
+  r = uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITABLE);
   ASSERT(r == 0);
  
   r = uv_pipe_init(uv_default_loop(), &child_pipes[0], UV_PIPE_READABLE|
@@ -512,14 +512,14 @@ TEST_IMPL(spawn_and_kill_with_std) {
   r = uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
   ASSERT(r == 0);
 
-  r = uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITEABLE|
+  r = uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITABLE|
 														UV_PIPE_SPAWN_SAFE);
   ASSERT(r == 0);
 
   r = uv_pipe_init(uv_default_loop(), &err, UV_PIPE_READABLE);
   ASSERT(r == 0);
 
-  r = uv_pipe_init(uv_default_loop(), &child_pipes[2], UV_PIPE_WRITEABLE|
+  r = uv_pipe_init(uv_default_loop(), &child_pipes[2], UV_PIPE_WRITABLE|
 														UV_PIPE_SPAWN_SAFE);
   ASSERT(r == 0);
 
@@ -585,11 +585,11 @@ TEST_IMPL(spawn_and_ping) {
   buf = uv_buf_init("TEST", 4);
 
   uv_pipe_init(uv_default_loop(), &child_pipes[0], UV_PIPE_READABLE|UV_PIPE_SPAWN_SAFE);
-  uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITEABLE);
+  uv_pipe_init(uv_default_loop(), &in, UV_PIPE_WRITABLE);
   r = uv_pipe_link(&child_pipes[0],&in);
   ASSERT(r == 0);
   uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITEABLE|UV_PIPE_SPAWN_SAFE);
+  uv_pipe_init(uv_default_loop(), &child_pipes[1], UV_PIPE_WRITABLE|UV_PIPE_SPAWN_SAFE);
   r = uv_pipe_link(&out,&child_pipes[1]);
   ASSERT(r == 0);
   options.stdio = stdio;
@@ -675,7 +675,7 @@ TEST_IMPL(spawn_detect_pipe_name_collisions_on_windows) {
   init_process_options("spawn_helper2", exit_cb);
 
   uv_pipe_init(uv_default_loop(), &out, UV_PIPE_READABLE);
-  uv_pipe_init(uv_default_loop(), &child_stdout, UV_PIPE_WRITEABLE|UV_PIPE_SPAWN_SAFE);
+  uv_pipe_init(uv_default_loop(), &child_stdout, UV_PIPE_WRITABLE|UV_PIPE_SPAWN_SAFE);
 
   /* Create a pipe that'll cause a collision. */
   _snprintf(name, sizeof(name), "\\\\.\\pipe\\uv\\%p-%d", &out, GetCurrentProcessId());

--- a/test/test-stdio-over-pipes.c
+++ b/test/test-stdio-over-pipes.c
@@ -124,12 +124,12 @@ TEST_IMPL(stdio_over_pipes) {
   init_process_options("stdio_over_pipes_helper", exit_cb);
 
   uv_pipe_init(loop, &child_pipes[0], UV_PIPE_SPAWN_SAFE|UV_PIPE_READABLE);
-  uv_pipe_init(loop, &in, UV_PIPE_WRITEABLE);
+  uv_pipe_init(loop, &in, UV_PIPE_WRITABLE);
   r = uv_pipe_link(&child_pipes[0],&in);
   ASSERT( r == 0 );
   
   uv_pipe_init(loop, &out, UV_PIPE_READABLE);
-  uv_pipe_init(loop, &child_pipes[1], UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITEABLE);
+  uv_pipe_init(loop, &child_pipes[1], UV_PIPE_SPAWN_SAFE|UV_PIPE_WRITABLE);
   r = uv_pipe_link(&out,&child_pipes[1]);
   ASSERT( r == 0 );
 


### PR DESCRIPTION
... but also "fix" a typo in the pipe API, or perhaps alter it to suit convention: libuv uses WRITABLE not WRITEABLE, also the former better passes the "google test".
