### PR TITLE
Work-around for unsupported volume info query

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -843,9 +843,13 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
                                             FileFsVolumeInformation);
 
   /* Buffer overflow (a warning status code) is expected here. */
-  if (NT_ERROR(nt_status)) {
+  if (io_status.Status == STATUS_NOT_IMPLEMENTED) {
+    statbuf->st_dev = 0;
+  } else if (NT_ERROR(nt_status)) {
     SetLastError(pRtlNtStatusToDosError(nt_status));
     return -1;
+  } else {
+    statbuf->st_dev = volume_info.VolumeSerialNumber;
   }
 
   /* Todo: st_mode should probably always be 0666 for everyone. We might also
@@ -901,8 +905,6 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
       file_info.StandardInformation.AllocationSize.QuadPart >> 9ULL;
 
   statbuf->st_nlink = file_info.StandardInformation.NumberOfLinks;
-
-  statbuf->st_dev = volume_info.VolumeSerialNumber;
 
   /* The st_blksize is supposed to be the 'optimal' number of bytes for reading
    * and writing to the disk. That is, for any definition of 'optimal' - it's


### PR DESCRIPTION
Wine does not currently support FileFsVolumeInformation:

https://github.com/mirrors/wine/blob/0e42fd97c05beb50c0788164647631c00485623b/dlls/ntdll/file.c#L2679

so check io_status and fallback to previous behavior if not implemented
