### PR TITLE
Fix segfaults on OSX

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -54,7 +54,7 @@ int uv_tty_init(uv_loop_t* loop, uv_tty_t* tty, int fd, int readable) {
    * different struct file, hence changing its properties doesn't affect
    * other processes.
    */
-  if (isatty(fd)) {
+  if (0 && isatty(fd)) {
     r = uv__open_cloexec("/dev/tty", O_RDWR);
 
     if (r < 0) {


### PR DESCRIPTION
This reverts commit 30d0897c79f48ee883589abea0bbc319240c44cb.

This has been [causing segfaults](https://github.com/JuliaLang/julia/issues/7344) on OSX builds.  Reverting this reversion fixes the issue.
