### PR TITLE
Fix execvpe not found error for glibc < 2.11

### DIFF
--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -42,6 +42,46 @@ extern char **environ;
 
 #ifdef __linux__
 # include <grp.h>
+# ifdef __GLIBC_PREREQ
+#  if ! (__GLIBC_PREREQ(2,11))
+int execvpe(const char *file, char *const argv[], char *const envp[])
+{
+	const char *p, *z, *path = getenv("PATH");
+	size_t l, k;
+
+	errno = ENOENT;
+	if (!*file) return -1;
+
+	if (strchr(file, '/'))
+		return execve(file, argv, envp);
+
+	if (!path) path = "/usr/local/bin:/bin:/usr/bin";
+	k = strnlen(file, NAME_MAX+1);
+	if (k > NAME_MAX) {
+		errno = ENAMETOOLONG;
+		return -1;
+	}
+	l = strnlen(path, PATH_MAX-1)+1;
+
+	for(p=path; ; p=z) {
+		char b[l+k+1];
+		z = strchr(p, ':');
+		if (!z) z = p+strlen(p);
+		if (z-p >= l) {
+			if (!*z++) break;
+			continue;
+		}
+		memcpy(b, p, z-p);
+		b[z-p] = '/';
+		memcpy(b+(z-p)+(z>p), file, k+1);
+		execve(b, argv, envp);
+		if (errno != ENOENT) return -1;
+		if (!*z++) break;
+	}
+	return -1;
+}
+#  endif
+# endif
 #endif
 
 


### PR DESCRIPTION
ref #24
This implementation is from musl-libc, which is MIT licensed. If this is deemed to be a "substantial portion," I can add in the copyright notice as well.

This should get skipped on a modern-enough distribution, would appreciate if someone could verify that.
