### PR TITLE
Fix uv_tty_set_mode raw mode not being raw enough

### DIFF
--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -124,7 +124,8 @@ int uv_tty_set_mode(uv_tty_t* tty, int mode) {
 
     raw = tty->orig_termios;
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
-    raw.c_oflag |= (ONLCR);
+    raw.c_oflag &= ~(OPOST);
+    raw.c_cflag &= ~(CSIZE | PARENB);
     raw.c_cflag |= (CS8);
     raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
     raw.c_cc[VMIN] = 1;

--- a/src/unix/tty.c
+++ b/src/unix/tty.c
@@ -123,11 +123,15 @@ int uv_tty_set_mode(uv_tty_t* tty, int mode) {
     uv_spinlock_unlock(&termios_spinlock);
 
     raw = tty->orig_termios;
-    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
-    raw.c_oflag &= ~(OPOST);
+#ifdef _BSD_SOURCE
+    cfmakeraw(&raw);
+#else
+    raw.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+    raw.c_oflag &= ~OPOST;
+    raw.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
     raw.c_cflag &= ~(CSIZE | PARENB);
-    raw.c_cflag |= (CS8);
-    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    raw.c_cflag |= CS8;
+#endif
     raw.c_cc[VMIN] = 1;
     raw.c_cc[VTIME] = 0;
 


### PR DESCRIPTION
Remove output CR translation (and output postprocessing), parity generation/checking from uv_tty_setmode.

I was attempting to use Terminals.raw! to implement clean I/O with a pty, but noticed that the output wasn't as expected, with LF being translated to CRLF by the line driver. `uv_tty_set_mode` seems pretty old in libuv, I doubt anybody ever noticed. The settings now match the Python tty.setraw module.

I use it here: https://github.com/wavexx/Expect.jl/blob/master/src/Expect.jl
