### PR TITLE
remove -xnolibs dtrace flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -308,7 +308,7 @@ endif
 
 if HAVE_DTRACE
 include/uv-dtrace.h: src/unix/uv-dtrace.d
-	$(AM_V_GEN)$(DTRACE) $(DTRACEFLAGS) -h -xnolibs -s $< -o $(top_srcdir)/$@
+	$(AM_V_GEN)$(DTRACE) $(DTRACEFLAGS) -h -s $< -o $(top_srcdir)/$@
 endif
 
 if DTRACE_NEEDS_OBJECTS

--- a/Makefile.in
+++ b/Makefile.in
@@ -3949,7 +3949,7 @@ uninstall-am: uninstall-includeHEADERS uninstall-libLTLIBRARIES \
 
 
 @HAVE_DTRACE_TRUE@include/uv-dtrace.h: src/unix/uv-dtrace.d
-@HAVE_DTRACE_TRUE@	$(AM_V_GEN)$(DTRACE) $(DTRACEFLAGS) -h -xnolibs -s $< -o $(top_srcdir)/$@
+@HAVE_DTRACE_TRUE@	$(AM_V_GEN)$(DTRACE) $(DTRACEFLAGS) -h -s $< -o $(top_srcdir)/$@
 
 @DTRACE_NEEDS_OBJECTS_TRUE@src/unix/uv-dtrace.o: src/unix/uv-dtrace.d ${libuv_la_OBJECTS}
 


### PR DESCRIPTION
Remove the `-xnolibs` option to the dtrace call to address https://github.com/JuliaLang/julia/issues/9058

Some of the tests fail.

Output from `$ make check`

```
  CCLD     test/run-tests
[%   0|+   0|-   0|T   0|S   0]: platform_output
Output from process `platform_output`:
uv_get_process_title: /home/nwh/git/libuv/test/.libs/lt-run-tests
uv_resident_set_memory: 1015808
uv_uptime: 158353.000000
uv_getrusage:
  user: 0 sec 0 microsec
  system: 0 sec 1016 microsec
uv_cpu_info:
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 2949
  times.sys: 3491400
  times.user: 11265400
  times.idle: 1565420500
  times.irq: 100
  times.nice: 248600
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 2671
  times.sys: 2914600
  times.user: 11396600
  times.idle: 1567011000
  times.irq: 0
  times.nice: 244800
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3686
  times.sys: 3047200
  times.user: 12233600
  times.idle: 1566438200
  times.irq: 0
  times.nice: 241600
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3366
  times.sys: 3300500
  times.user: 12766200
  times.idle: 1563566500
  times.irq: 0
  times.nice: 250300
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3431
  times.sys: 1276400
  times.user: 8317700
  times.idle: 1573391700
  times.irq: 0
  times.nice: 83700
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3593
  times.sys: 1521200
  times.user: 9996800
  times.idle: 1571099800
  times.irq: 0
  times.nice: 88600
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3599
  times.sys: 1340400
  times.user: 9648300
  times.idle: 1562191000
  times.irq: 100
  times.nice: 161100
  model: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
  speed: 3366
  times.sys: 1270000
  times.user: 10593900
  times.idle: 1569411300
  times.irq: 0
  times.nice: 85000
uv_interface_addresses:
  name: lo
  internal: 1
  physical address: 00:00:00:00:00:00
  address: 127.0.0.1
  netmask: 255.0.0.0
  name: p4p1
  internal: 0
  physical address: 30:85:a9:94:54:86
  address: 171.67.87.69
  netmask: 255.255.255.0
  name: lo
  internal: 1
  physical address: 00:00:00:00:00:00
  address: ::1
  netmask: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
  name: p4p1
  internal: 0
  physical address: 30:85:a9:94:54:86
  address: fe80::3285:a9ff:fe94:5486
  netmask: ffff:ffff:ffff:ffff::
=============================================================
[%  11|+  25|-   0|T   0|S   0]: ipc_listen_before_write
`ipc_listen_before_write` failed: exit code 134
Output from process `ipc_listen_before_write`:
lt-run-tests: src/unix/pipe.c:119: uv_pipe_link: Assertion `!(write->flags & UV__PIPE_IPC)' failed.
=============================================================
[%  11|+  25|-   1|T   0|S   0]: ipc_listen_after_write
`ipc_listen_after_write` failed: exit code 134
Output from process `ipc_listen_after_write`:
lt-run-tests: src/unix/pipe.c:119: uv_pipe_link: Assertion `!(write->flags & UV__PIPE_IPC)' failed.
=============================================================
[%  12|+  25|-   2|T   0|S   0]: ipc_send_recv_pipe
`ipc_send_recv_pipe` failed: exit code 134
Output from process `ipc_send_recv_pipe`:
lt-run-tests: src/unix/pipe.c:119: uv_pipe_link: Assertion `!(write->flags & UV__PIPE_IPC)' failed.
=============================================================
[%  12|+  25|-   3|T   0|S   0]: ipc_send_recv_tcp
`ipc_send_recv_tcp` failed: exit code 134
Output from process `ipc_send_recv_tcp`:
lt-run-tests: src/unix/pipe.c:119: uv_pipe_link: Assertion `!(write->flags & UV__PIPE_IPC)' failed.
=============================================================
[%  12|+  25|-   4|T   0|S   0]: ipc_tcp_connection
`ipc_tcp_connection` failed: exit code 134
Output from process `ipc_tcp_connection`:
lt-run-tests: src/unix/pipe.c:119: uv_pipe_link: Assertion `!(write->flags & UV__PIPE_IPC)' failed.
=============================================================
[%  72|+ 159|-   5|T   0|S   0]: spawn_closed_process_io
`spawn_closed_process_io` failed: exit code 134
Output from process `spawn_closed_process_io`:
close_cb
exit_cb
close_cb
lt-run-tests: src/unix/loop.c:93: uv_loop_delete: Assertion `uv_loop_close(loop) == 0' failed.
=============================================================
[%  94|+ 207|-   6|T   0|S   0]: threadpool_multiple_event_loops
`threadpool_multiple_event_loops` failed: timeout
Output from process `threadpool_multiple_event_loops`: (no output)
=============================================================
[% 100|+ 218|-   7|T   0|S   0]: Done.
FAIL: test/run-tests
=======================================================
1 of 1 test failed
Please report to https://github.com/joyent/libuv/issues
=======================================================
make[2]: *** [check-TESTS] Error 1
make[2]: Leaving directory `/home/nwh/git/libuv'
make[1]: *** [check-am] Error 2
make[1]: Leaving directory `/home/nwh/git/libuv'
make: *** [check] Error 2
```
