### PR TITLE
[0.4] linux: try epoll_pwait if epoll_wait is missing

### DIFF
--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -149,6 +149,7 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   int fd;
   int op;
   int i;
+  static int no_epoll_wait;
 
   if (loop->nfds == 0) {
     assert(QUEUE_EMPTY(&loop->watcher_queue));
@@ -199,10 +200,22 @@ void uv__io_poll(uv_loop_t* loop, int timeout) {
   count = 48; /* Benchmarks suggest this gives the best throughput. */
 
   for (;;) {
-    nfds = uv__epoll_wait(loop->backend_fd,
-                          events,
-                          ARRAY_SIZE(events),
-                          timeout);
+    if (!no_epoll_wait) {
+      nfds = uv__epoll_wait(loop->backend_fd,
+                            events,
+                            ARRAY_SIZE(events),
+                            timeout);
+      if (nfds == -1 && errno == ENOSYS) {
+        no_epoll_wait = 1;
+        continue;
+      }
+    } else {
+      nfds = uv__epoll_pwait(loop->backend_fd,
+                             events,
+                             ARRAY_SIZE(events),
+                             timeout,
+                             NULL);
+    }
 
     /* Update loop->time unconditionally. It's tempting to skip the update when
      * timeout == 0 (i.e. non-blocking poll) but there is no guarantee that the


### PR DESCRIPTION
This is the 0.4 backport version of https://github.com/JuliaLang/libuv/pull/36 fixes bootstrap on aarch64 on 0.4. We could have more test on the master before merging and I'm only opening this as a reminder.
