### PR TITLE
Add missing static on uv_cond_wait_helper

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -529,7 +529,7 @@ void uv_cond_broadcast(uv_cond_t* cond) {
 }
 
 
-inline int uv_cond_wait_helper(uv_cond_t* cond, uv_mutex_t* mutex,
+inline static int uv_cond_wait_helper(uv_cond_t* cond, uv_mutex_t* mutex,
     DWORD dwMilliseconds) {
   DWORD result;
   int last_waiter;


### PR DESCRIPTION
This is libuv/libuv#191. The patch is different, since it's less invasive for when we want to rebase.
