### PR TITLE
Revert "win pipe: race condition on queueing uv_pipe_zero_readfile_th…

### DIFF
--- a/src/win/pipe.c
+++ b/src/win/pipe.c
@@ -1114,6 +1114,7 @@ static DWORD WINAPI uv_pipe_zero_readfile_thread_proc(void* parameter) {
   assert(handle->type == UV_NAMED_PIPE);
 
   if (handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE) {
+    uv_mutex_lock(m); /* mutex controls *setting* of readfile_thread */
     if (DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
                         GetCurrentProcess(), &hThread,
                         0, TRUE, DUPLICATE_SAME_ACCESS)) {
@@ -1247,13 +1248,9 @@ static void uv_pipe_queue_read(uv_loop_t* loop, uv_pipe_t* handle) {
   req = &handle->read_req;
 
   if (handle->flags & UV_HANDLE_NON_OVERLAPPED_PIPE) {
-    if (handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE)
-        uv_mutex_lock(&handle->pipe.conn.readfile_mutex); /* mutex controls *setting* of readfile_thread */
     if (!QueueUserWorkItem(&uv_pipe_zero_readfile_thread_proc,
                            req,
                            WT_EXECUTELONGFUNCTION)) {
-      if (handle->flags & UV_HANDLE_PIPE_READ_CANCELABLE)
-          uv_mutex_unlock(&handle->pipe.conn.readfile_mutex);
       /* Make this req pending reporting an error. */
       SET_REQ_ERROR(req, GetLastError());
       goto error;


### PR DESCRIPTION
…read_proc"

This reverts commit dd0702a3f397755095c7467dc9efc7b6def33b98.

See discussion at https://github.com/JuliaLang/libuv/commit/de067bc4da4cda1f8e629e3a37ae4076b91d8766#commitcomment-14457130

I'm testing locally whether this fixes (once merged in julia) https://github.com/JuliaLang/julia/issues/16556. cc @vtjnash the original commit has a pretty weak justification "another similar issue that i assume could happen" so I'm going to guess we can afford to drop this if it fixes matters.
