### PR TITLE
Fix spurious warnings when file watching on OS X

### DIFF
--- a/src/unix/fsevents.c
+++ b/src/unix/fsevents.c
@@ -378,9 +378,6 @@ static void uv__fsevents_destroy_stream(uv_loop_t* loop) {
   if (state->fsevent_stream == NULL)
     return;
 
-  /* Flush all accumulated events */
-  pFSEventStreamFlushSync(state->fsevent_stream);
-
   /* Stop emitting events */
   pFSEventStreamStop(state->fsevent_stream);
 


### PR DESCRIPTION
When using Revise.jl on my MacBook Pro, my REPL becomes polluted with warnings like the following. It happens every time I save a watched file, but only after something in the file has been called once in julia:

```
2018-01-06 14:57 julia[23477] (FSEvents.framework) FSEventStreamFlushSync(): failed assertion '(SInt64)last_id > 0LL'
```

These statements seem to be harmless but they are distracting. I looked around and apparently this issue has been seen elsewhere, is due to libuv, and is now patched upstream. See https://github.com/libuv/libuv/pull/1349 and links therein, especially [this one](https://github.com/nodejs/node/issues/854). I cherry-picked that commit and made this PR after having confirmed that I no longer experience problems when I build the latest julia nightly using this branch of libuv.