### PR TITLE
Use whitelists instead of blacklists for some ifdefs

### DIFF
--- a/include/uv/bsd.h
+++ b/include/uv/bsd.h
@@ -22,8 +22,11 @@
 #ifndef UV_BSD_H
 #define UV_BSD_H
 
+#if defined(__FreeBSD__)
+/* Not supported on other BSDs */
 #include <pthread_np.h>
 typedef cpuset_t cpu_set_t;
+#endif
 
 #define UV_PLATFORM_FS_EVENT_FIELDS                                           \
   uv__io_t event_watcher;                                                     \

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -1321,9 +1321,9 @@ int uv_os_gethostname(char* buffer, size_t* size) {
 
 
 int uv_cpumask_size(void) {
-#if defined(__APPLE__) && defined(__MACH__) || defined(_AIX)
-  return -ENOTSUP;
-#else /* !((defined(__APPLE__) && defined(__MACH__)) || defined(_AIX)) */
+#if defined(__linux__) || defined(__FreeBSD__)
   return CPU_SETSIZE;
+#else
+  return -ENOTSUP;
 #endif
 }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -82,22 +82,7 @@ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
 }
 
 
-#if defined(__APPLE__) && defined(__MACH__) || defined(_AIX)
-int uv_thread_setaffinity(uv_thread_t* tid,
-                          char* cpumask,
-                          char* oldmask,
-                          size_t mask_size) {
-  return -ENOTSUP;
-}
-
-
-int uv_thread_getaffinity(uv_thread_t* tid,
-                          char* cpumask,
-                          size_t mask_size) {
-  return -ENOTSUP;
-}
-
-#else /* !((defined(__APPLE__) && defined(__MACH__)) || defined(_AIX)) */
+#if defined(__linux__) || defined(__FreeBSD__)
 
 int uv_thread_setaffinity(uv_thread_t* tid,
                           char* cpumask,
@@ -143,7 +128,24 @@ int uv_thread_getaffinity(uv_thread_t* tid,
 
   return 0;
 }
-#endif /* (defined(__APPLE__) && defined(__MACH__)) || defined(_AIX) */
+
+#else
+
+int uv_thread_setaffinity(uv_thread_t* tid,
+                          char* cpumask,
+                          char* oldmask,
+                          size_t mask_size) {
+  return -ENOTSUP;
+}
+
+
+int uv_thread_getaffinity(uv_thread_t* tid,
+                          char* cpumask,
+                          size_t mask_size) {
+  return -ENOTSUP;
+}
+
+#endif /* defined(__linux__) || defined(__FreeBSD__) */
 
 int uv_thread_detach(uv_thread_t* tid) {
   return -pthread_detach(*tid);


### PR DESCRIPTION
This is the pattern used upstream and allows building on platforms such as OpenBSD and DragonFly, which don't get caught by the current blacklist and thus fail on unsupported features.