### PR TITLE
Fix warning; match uv_fs_type order to upstream

### DIFF
--- a/include/uv.h
+++ b/include/uv.h
@@ -1244,9 +1244,9 @@ typedef enum {
   UV_FS_READLINK,
   UV_FS_CHOWN,
   UV_FS_FCHOWN,
-  UV_FS_LCHOWN,
   UV_FS_REALPATH,
-  UV_FS_COPYFILE
+  UV_FS_COPYFILE,
+  UV_FS_LCHOWN
 } uv_fs_type;
 
 /* uv_fs_t is a subclass of uv_req_t. */
@@ -1460,12 +1460,6 @@ UV_EXTERN int uv_fs_chown(uv_loop_t* loop,
 UV_EXTERN int uv_fs_fchown(uv_loop_t* loop,
                            uv_fs_t* req,
                            uv_os_fd_t file,
-                           uv_uid_t uid,
-                           uv_gid_t gid,
-                           uv_fs_cb cb);
-UV_EXTERN int uv_fs_lchown(uv_loop_t* loop,
-                           uv_fs_t* req,
-                           const char* path,
                            uv_uid_t uid,
                            uv_gid_t gid,
                            uv_fs_cb cb);


### PR DESCRIPTION
This removes a duplicate declaration of `uv_fs_lchown`, and adjusts the order
of `UV_FS_LCHOWN` inside `uv_fs_type` to match upstream libuv.

Resolves https://github.com/JuliaLang/julia/issues/30264